### PR TITLE
Update ConvexMobile.swift

### DIFF
--- a/Sources/ConvexMobile/ConvexMobile.swift
+++ b/Sources/ConvexMobile/ConvexMobile.swift
@@ -189,7 +189,7 @@ public protocol AuthProvider<T, LoginParams> {
 /// The generic parameter `T` matches the type of data returned by the ``AuthProvider`` upon successful
 /// authentication.
 public class ConvexClientWithAuth<T, LoginParams>: ConvexClient {
-  private let authPublisher = CurrentValueSubject<AuthState<T>, Never>(AuthState.unauthenticated)
+  private let authPublisher = CurrentValueSubject<AuthState<T>, Never>(AuthState.loading)
   private let authProvider: any AuthProvider<T, LoginParams>
 
   /// A publisher that updates with the current ``AuthState`` of this client instance.


### PR DESCRIPTION
Fix initial auth state by making it `loading` instead of `unauthenticated`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App now starts in an authenticating state, showing a loading indicator while verifying the session instead of briefly appearing logged out.
  * Reduces flicker and unintended exposure of unauthenticated UI on launch, providing a smoother transition once the sign-in status is determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->