### PR TITLE
Add async query methods to ConvexClient

### DIFF
--- a/Sources/ConvexMobile/ConvexMobile.swift
+++ b/Sources/ConvexMobile/ConvexMobile.swift
@@ -82,6 +82,32 @@ public class ConvexClient {
     .eraseToAnyPublisher()
   }
 
+  /// Executes the query with the given `name` and `args` without returning a result.
+  ///
+  /// For queries that return a value, prefer calling the version of this method that returns a ``Decodable`` value.
+  ///
+  /// - Parameters:
+  ///   - name: A value in "module:mutation_name"  format that will be used when calling the backend
+  ///   - args: An optional ``Dictionary`` of arguments to be sent to the backend mutation function
+  public func query<T: Decodable>(_ name: String, with args: [String: ConvexEncodable?]? = nil)
+    async throws -> T
+  {
+    try await callForResult(name: name, args: args, remoteCall: ffiClient.query)
+  }
+
+  /// Executes the query with the given `name` and `args` without returning a result.
+  ///
+  /// For queries that return a value, prefer calling the version of this method that returns a ``Decodable`` value.
+  ///
+  /// - Parameters:
+  ///   - name: A value in "module:mutation_name"  format that will be used when calling the backend
+  ///   - args: An optional ``Dictionary`` of arguments to be sent to the backend mutation function
+  public func query(_ name: String, with args: [String: ConvexEncodable?]? = nil)
+    async throws
+  {
+    let _: String? = try await query(name, with: args)
+  }
+
   /// Executes the mutation with the given `name` and `args` and returns the result.
   ///
   /// For mutations that don't return a value, prefer calling the version of this method that doesn't return a value.


### PR DESCRIPTION
## Summary
- Adds generic `query(_:with:)` method that returns a `Decodable` value
- Adds void `query(_:with:)` method for queries that don't return a result
- Mirrors the existing mutation method pattern for consistency

## Test plan
- [ ] Verify the new query methods compile correctly
- [ ] Test calling a Convex query function using the new async API
- [ ] Verify the void version works for queries with no meaningful return value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query operations now support retrieving strongly-typed results from the server, enabling seamless integration of query responses with type-safe Swift code
  * Added a convenience query variant that allows queries to be executed without requiring explicit result handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->